### PR TITLE
Add new schema files for basic, advanced, and composite foreign keys

### DIFF
--- a/drizzle/mysql/advanced/schema.ts
+++ b/drizzle/mysql/advanced/schema.ts
@@ -1,0 +1,427 @@
+import {
+  mysqlSchema,
+  serial,
+  text,
+  varchar,
+  int,
+  bigint,
+  boolean,
+  timestamp,
+  decimal,
+  json,
+  char,
+  date,
+  time,
+  index,
+  uniqueIndex,
+  primaryKey,
+  unique,
+  check,
+} from 'drizzle-orm/mysql-core'
+import { relations, sql } from 'drizzle-orm'
+
+// ========================================
+// 1. Multiple Schemas Testing
+// ========================================
+
+// Auth schema for user authentication
+export const authSchema = mysqlSchema('auth')
+
+// Public schema (default)
+export const publicSchema = mysqlSchema('public')
+
+// Analytics schema for reporting
+export const analyticsSchema = mysqlSchema('analytics')
+
+// Admin schema for administrative functions
+export const adminSchema = mysqlSchema('admin')
+
+// ========================================
+// Auth Schema Tables
+// ========================================
+
+export const authUsers = authSchema.table('users', {
+  id: char('id', { length: 36 }).primaryKey().$defaultFn(() => crypto.randomUUID()),
+  email: varchar('email', { length: 255 }).notNull().unique(),
+  passwordHash: text('password_hash').notNull(),
+  isEmailVerified: boolean('is_email_verified').default(false).notNull(),
+  emailVerificationToken: text('email_verification_token'),
+  passwordResetToken: text('password_reset_token'),
+  passwordResetExpiresAt: timestamp('password_reset_expires_at'),
+  lastLoginAt: timestamp('last_login_at'),
+  loginAttempts: int('login_attempts').default(0).notNull(),
+  lockedUntil: timestamp('locked_until'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull().onUpdateNow(),
+}, (table) => ({
+  emailIdx: uniqueIndex('auth_users_email_idx').on(table.email),
+  verificationTokenIdx: index('auth_users_verification_token_idx').on(table.emailVerificationToken),
+  resetTokenIdx: index('auth_users_reset_token_idx').on(table.passwordResetToken),
+  // Index for locked accounts
+  lockedAccountsIdx: index('auth_users_locked_accounts_idx')
+    .on(table.lockedUntil),
+  // CHECK constraints
+  loginAttemptsCheck: check('auth_users_login_attempts_check', sql`login_attempts >= 0 AND login_attempts <= 10`),
+}))
+
+export const authSessions = authSchema.table('sessions', {
+  id: char('id', { length: 36 }).primaryKey().$defaultFn(() => crypto.randomUUID()),
+  userId: char('user_id', { length: 36 }).notNull().references(() => authUsers.id, {
+    onDelete: 'cascade',
+    onUpdate: 'cascade',
+  }),
+  token: text('token').notNull().unique(),
+  expiresAt: timestamp('expires_at').notNull(),
+  ipAddress: varchar('ip_address', { length: 45 }), // IPv6 support
+  userAgent: text('user_agent'),
+  isActive: boolean('is_active').default(true).notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => ({
+  userIdIdx: index('auth_sessions_user_id_idx').on(table.userId),
+  tokenIdx: uniqueIndex('auth_sessions_token_idx').on(table.token),
+  // Index for active sessions
+  activeSessionsIdx: index('auth_sessions_active_idx')
+    .on(table.userId, table.expiresAt, table.isActive),
+  // CHECK constraint for expiration
+  expirationCheck: check('auth_sessions_expiration_check', sql`expires_at > created_at`),
+}))
+
+// ========================================
+// Public Schema Tables
+// ========================================
+
+export const publicEvents = publicSchema.table('events', {
+  id: serial('id').primaryKey(),
+  title: varchar('title', { length: 255 }).notNull(),
+  description: text('description'),
+  // Date range simulation using start/end dates
+  startDate: date('start_date').notNull(),
+  endDate: date('end_date').notNull(),
+  // Time range simulation
+  startTime: timestamp('start_time'),
+  endTime: timestamp('end_time'),
+  // Price range simulation
+  minPrice: decimal('min_price', { precision: 10, scale: 2 }),
+  maxPrice: decimal('max_price', { precision: 10, scale: 2 }),
+  // Participant count range
+  minParticipants: int('min_participants'),
+  maxParticipants: int('max_participants'),
+  // Age restriction range
+  minAge: int('min_age'),
+  maxAge: int('max_age'),
+  location: text('location'),
+  organizerId: char('organizer_id', { length: 36 }).references(() => authUsers.id, {
+    onDelete: 'restrict',
+    onUpdate: 'cascade',
+  }),
+  currentParticipants: int('current_participants').default(0).notNull(),
+  isPublic: boolean('is_public').default(true).notNull(),
+  tags: json('tags').$type<string[]>(),
+  metadata: json('metadata'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull().onUpdateNow(),
+}, (table) => ({
+  // Date range indexes
+  dateRangeIdx: index('events_date_range_idx').on(table.startDate, table.endDate),
+  timeRangeIdx: index('events_time_range_idx').on(table.startTime, table.endTime),
+  // Regular indexes
+  organizerIdx: index('events_organizer_idx').on(table.organizerId),
+  publicEventsIdx: index('events_public_idx')
+    .on(table.isPublic),
+  // JSON indexes
+  tagsIdx: index('events_tags_idx').on(table.tags),
+  // CHECK constraints
+  participantsCheck: check('events_participants_check', 
+    sql`current_participants >= 0 AND (max_participants IS NULL OR current_participants <= max_participants)`),
+  maxParticipantsCheck: check('events_max_participants_check', sql`max_participants IS NULL OR max_participants > 0`),
+  dateRangeCheck: check('events_date_range_check', sql`end_date >= start_date`),
+  timeRangeCheck: check('events_time_range_check', sql`end_time IS NULL OR start_time IS NULL OR end_time >= start_time`),
+  priceRangeCheck: check('events_price_range_check', sql`max_price IS NULL OR min_price IS NULL OR max_price >= min_price`),
+  ageRangeCheck: check('events_age_range_check', sql`max_age IS NULL OR min_age IS NULL OR max_age >= min_age`),
+}))
+
+export const publicBookings = publicSchema.table('bookings', {
+  id: serial('id').primaryKey(),
+  eventId: int('event_id').notNull().references(() => publicEvents.id, {
+    onDelete: 'cascade',
+    onUpdate: 'cascade',
+  }),
+  userId: char('user_id', { length: 36 }).notNull().references(() => authUsers.id, {
+    onDelete: 'restrict',
+    onUpdate: 'cascade',
+  }),
+  // Booking time range simulation
+  bookingStartTime: timestamp('booking_start_time').notNull(),
+  bookingEndTime: timestamp('booking_end_time').notNull(),
+  participantCount: int('participant_count').notNull(),
+  totalPrice: decimal('total_price', { precision: 10, scale: 2 }).notNull(),
+  status: varchar('status', { length: 20 }).default('pending').notNull(),
+  notes: text('notes'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull().onUpdateNow(),
+}, (table) => ({
+  eventUserIdx: index('bookings_event_user_idx').on(table.eventId, table.userId),
+  userBookingsIdx: index('bookings_user_idx').on(table.userId),
+  timeRangeIdx: index('bookings_time_range_idx').on(table.bookingStartTime, table.bookingEndTime),
+  statusIdx: index('bookings_status_idx').on(table.status),
+  // Unique constraint to prevent double booking
+  eventUserTimeUnique: unique('bookings_event_user_time_unique')
+    .on(table.eventId, table.userId, table.bookingStartTime),
+  // CHECK constraints
+  participantCountCheck: check('bookings_participant_count_check', sql`participant_count > 0`),
+  totalPriceCheck: check('bookings_total_price_check', sql`total_price >= 0`),
+  timeRangeCheck: check('bookings_time_range_check', sql`booking_end_time > booking_start_time`),
+}))
+
+// ========================================
+// Analytics Schema Tables
+// ========================================
+
+export const analyticsPageViews = analyticsSchema.table('page_views', {
+  id: bigint('id', { mode: 'bigint' }).primaryKey(),
+  userId: char('user_id', { length: 36 }).references(() => authUsers.id, {
+    onDelete: 'set null',
+    onUpdate: 'cascade',
+  }),
+  sessionId: char('session_id', { length: 36 }).references(() => authSessions.id, {
+    onDelete: 'set null',
+    onUpdate: 'cascade',
+  }),
+  url: text('url').notNull(),
+  referrer: text('referrer'),
+  userAgent: text('user_agent'),
+  ipAddress: varchar('ip_address', { length: 45 }),
+  countryCode: varchar('country_code', { length: 2 }),
+  duration: time('duration'), // MySQL doesn't have interval type
+  viewedAt: timestamp('viewed_at').defaultNow().notNull(),
+}, (table) => ({
+  userIdIdx: index('analytics_page_views_user_id_idx').on(table.userId),
+  sessionIdIdx: index('analytics_page_views_session_id_idx').on(table.sessionId),
+  urlIdx: index('analytics_page_views_url_idx').on(table.url),
+  viewedAtIdx: index('analytics_page_views_viewed_at_idx').on(table.viewedAt),
+  countryIdx: index('analytics_page_views_country_idx').on(table.countryCode),
+  // Composite index for analytics queries
+  urlDateIdx: index('analytics_page_views_url_date_idx').on(table.url, table.viewedAt),
+}))
+
+// ========================================
+// Admin Schema Tables
+// ========================================
+
+export const adminAuditLogs = adminSchema.table('audit_logs', {
+  id: bigint('id', { mode: 'bigint' }).primaryKey(),
+  userId: char('user_id', { length: 36 }).references(() => authUsers.id, {
+    onDelete: 'restrict',
+    onUpdate: 'cascade',
+  }),
+  action: varchar('action', { length: 100 }).notNull(),
+  tableName: varchar('table_name', { length: 100 }),
+  recordId: text('record_id'),
+  oldValues: json('old_values'),
+  newValues: json('new_values'),
+  ipAddress: varchar('ip_address', { length: 45 }),
+  userAgent: text('user_agent'),
+  performedAt: timestamp('performed_at').defaultNow().notNull(),
+}, (table) => ({
+  userIdIdx: index('admin_audit_logs_user_id_idx').on(table.userId),
+  actionIdx: index('admin_audit_logs_action_idx').on(table.action),
+  tableNameIdx: index('admin_audit_logs_table_name_idx').on(table.tableName),
+  performedAtIdx: index('admin_audit_logs_performed_at_idx').on(table.performedAt),
+  // Composite index for table-specific queries
+  tableRecordIdx: index('admin_audit_logs_table_record_idx').on(table.tableName, table.recordId),
+}))
+
+// ========================================
+// Foreign Key Constraints Example
+// ========================================
+
+export const publicProjects = publicSchema.table('projects', {
+  id: serial('id').primaryKey(),
+  name: varchar('name', { length: 255 }).notNull(),
+  ownerId: char('owner_id', { length: 36 }).notNull().references(() => authUsers.id, {
+    onDelete: 'restrict',
+    onUpdate: 'cascade',
+  }),
+  managerId: char('manager_id', { length: 36 }).references(() => authUsers.id, {
+    onDelete: 'set null',
+    onUpdate: 'cascade',
+  }),
+  status: varchar('status', { length: 20 }).default('planning').notNull(),
+  budget: decimal('budget', { precision: 12, scale: 2 }),
+  startDate: date('start_date'),
+  endDate: date('end_date'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull().onUpdateNow(),
+}, (table) => ({
+  ownerIdx: index('projects_owner_idx').on(table.ownerId),
+  managerIdx: index('projects_manager_idx').on(table.managerId),
+  statusIdx: index('projects_status_idx').on(table.status),
+  // CHECK constraints
+  dateRangeCheck: check('projects_date_range_check', 
+    sql`start_date IS NULL OR end_date IS NULL OR end_date >= start_date`),
+  budgetCheck: check('projects_budget_check', sql`budget IS NULL OR budget > 0`),
+}))
+
+// ========================================
+// Self-referential Tables
+// ========================================
+
+export const publicDepartments = publicSchema.table('departments', {
+  id: serial('id').primaryKey(),
+  name: varchar('name', { length: 100 }).notNull(),
+  managerId: char('manager_id', { length: 36 }),
+  parentDepartmentId: int('parent_department_id'),
+  budget: decimal('budget', { precision: 12, scale: 2 }),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => ({
+  managerIdx: index('departments_manager_idx').on(table.managerId),
+  parentIdx: index('departments_parent_idx').on(table.parentDepartmentId),
+}))
+
+export const publicEmployees = publicSchema.table('employees', {
+  id: char('id', { length: 36 }).primaryKey().$defaultFn(() => crypto.randomUUID()),
+  userId: char('user_id', { length: 36 }).notNull().unique().references(() => authUsers.id, {
+    onDelete: 'cascade',
+    onUpdate: 'cascade',
+  }),
+  employeeNumber: varchar('employee_number', { length: 20 }).notNull().unique(),
+  departmentId: int('department_id'),
+  managerId: char('manager_id', { length: 36 }),
+  position: varchar('position', { length: 100 }),
+  salary: decimal('salary', { precision: 10, scale: 2 }),
+  hireDate: date('hire_date').notNull(),
+  terminationDate: date('termination_date'),
+  isActive: boolean('is_active').default(true).notNull(),
+}, (table) => ({
+  userIdIdx: uniqueIndex('employees_user_id_idx').on(table.userId),
+  employeeNumberIdx: uniqueIndex('employees_employee_number_idx').on(table.employeeNumber),
+  departmentIdx: index('employees_department_idx').on(table.departmentId),
+  managerIdx: index('employees_manager_idx').on(table.managerId),
+  activeIdx: index('employees_active_idx')
+    .on(table.isActive),
+  // CHECK constraints
+  salaryCheck: check('employees_salary_check', sql`salary IS NULL OR salary > 0`),
+  datesCheck: check('employees_dates_check', 
+    sql`termination_date IS NULL OR termination_date >= hire_date`),
+}))
+
+// ========================================
+// Tables with Long Names and Reserved Words
+// ========================================
+
+// Table with very long name (near MySQL limit)
+export const publicVeryLongTableNameThatIsNearTheMySQLLimitOfSixtyFour = publicSchema.table('very_long_table_name_that_is_near_the_mysql_limit_of_64', {
+  id: serial('id').primaryKey(),
+  veryLongColumnNameThatIsAlsoNearTheLimit: text('very_long_column_name_that_is_also_near_the_limit'),
+})
+
+// Table using MySQL reserved words (should be quoted)
+export const publicOrder = publicSchema.table('order', {
+  id: serial('id').primaryKey(),
+  user: text('user'), // 'user' is a reserved word
+  group: text('group'), // 'group' is a reserved word
+  table: text('table'), // 'table' is a reserved word
+}, (table) => ({
+  // Index with reserved word
+  userIdx: index('order_user_idx').on(table.user),
+}))
+
+// ========================================
+// Relations for Cross-Schema References
+// ========================================
+
+export const authUsersRelations = relations(authUsers, ({ many }) => ({
+  sessions: many(authSessions),
+  events: many(publicEvents),
+  bookings: many(publicBookings),
+  pageViews: many(analyticsPageViews),
+  auditLogs: many(adminAuditLogs),
+  ownedProjects: many(publicProjects, { relationName: 'ProjectOwner' }),
+  managedProjects: many(publicProjects, { relationName: 'ProjectManager' }),
+  employee: many(publicEmployees),
+}))
+
+export const authSessionsRelations = relations(authSessions, ({ one, many }) => ({
+  user: one(authUsers, {
+    fields: [authSessions.userId],
+    references: [authUsers.id],
+  }),
+  pageViews: many(analyticsPageViews),
+}))
+
+export const publicEventsRelations = relations(publicEvents, ({ one, many }) => ({
+  organizer: one(authUsers, {
+    fields: [publicEvents.organizerId],
+    references: [authUsers.id],
+  }),
+  bookings: many(publicBookings),
+}))
+
+export const publicBookingsRelations = relations(publicBookings, ({ one }) => ({
+  event: one(publicEvents, {
+    fields: [publicBookings.eventId],
+    references: [publicEvents.id],
+  }),
+  user: one(authUsers, {
+    fields: [publicBookings.userId],
+    references: [authUsers.id],
+  }),
+}))
+
+export const publicProjectsRelations = relations(publicProjects, ({ one }) => ({
+  owner: one(authUsers, {
+    fields: [publicProjects.ownerId],
+    references: [authUsers.id],
+    relationName: 'ProjectOwner',
+  }),
+  manager: one(authUsers, {
+    fields: [publicProjects.managerId],
+    references: [authUsers.id],
+    relationName: 'ProjectManager',
+  }),
+}))
+
+export const publicDepartmentsRelations = relations(publicDepartments, ({ one, many }) => ({
+  parent: one(publicDepartments, {
+    fields: [publicDepartments.parentDepartmentId],
+    references: [publicDepartments.id],
+    relationName: 'DepartmentHierarchy',
+  }),
+  children: many(publicDepartments, {
+    relationName: 'DepartmentHierarchy',
+  }),
+  employees: many(publicEmployees),
+}))
+
+export const publicEmployeesRelations = relations(publicEmployees, ({ one, many }) => ({
+  user: one(authUsers, {
+    fields: [publicEmployees.userId],
+    references: [authUsers.id],
+  }),
+  manager: one(publicEmployees, {
+    fields: [publicEmployees.managerId],
+    references: [publicEmployees.id],
+    relationName: 'EmployeeHierarchy',
+  }),
+  subordinates: many(publicEmployees, {
+    relationName: 'EmployeeHierarchy',
+  }),
+}))
+
+export const analyticsPageViewsRelations = relations(analyticsPageViews, ({ one }) => ({
+  user: one(authUsers, {
+    fields: [analyticsPageViews.userId],
+    references: [authUsers.id],
+  }),
+  session: one(authSessions, {
+    fields: [analyticsPageViews.sessionId],
+    references: [authSessions.id],
+  }),
+}))
+
+export const adminAuditLogsRelations = relations(adminAuditLogs, ({ one }) => ({
+  user: one(authUsers, {
+    fields: [adminAuditLogs.userId],
+    references: [authUsers.id],
+  }),
+}))

--- a/drizzle/mysql/basic/schema.ts
+++ b/drizzle/mysql/basic/schema.ts
@@ -1,0 +1,417 @@
+import {
+  mysqlTable,
+  mysqlEnum,
+  serial,
+  text,
+  varchar,
+  int,
+  boolean,
+  timestamp,
+  decimal,
+  json,
+  index,
+  uniqueIndex,
+  primaryKey,
+  unique,
+  check,
+} from 'drizzle-orm/mysql-core'
+import { relations, sql } from 'drizzle-orm'
+
+// ========================================
+// ENUMs
+// ========================================
+
+export const userRoleEnum = mysqlEnum('user_role', ['admin', 'moderator', 'user', 'guest'])
+export const orderStatusEnum = mysqlEnum('order_status', ['pending', 'processing', 'shipped', 'delivered', 'cancelled'])
+export const paymentMethodEnum = mysqlEnum('payment_method', ['credit_card', 'paypal', 'bank_transfer', 'crypto'])
+
+// ========================================
+// Core Tables with Various Patterns
+// ========================================
+
+export const users = mysqlTable('users', {
+  id: serial('id').primaryKey(),
+  uuid: varchar('uuid', { length: 36 }).notNull().unique().$defaultFn(() => crypto.randomUUID()),
+  email: varchar('email', { length: 255 }).notNull().unique(),
+  username: varchar('username', { length: 50 }).notNull().unique(),
+  passwordHash: text('password_hash').notNull(),
+  firstName: varchar('first_name', { length: 100 }).notNull(),
+  lastName: varchar('last_name', { length: 100 }).notNull(),
+  role: userRoleEnum('role').default('user').notNull(),
+  age: int('age'),
+  isActive: boolean('is_active').default(true).notNull(),
+  isEmailVerified: boolean('is_email_verified').default(false).notNull(),
+  lastLoginAt: timestamp('last_login_at'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull().onUpdateNow(),
+  bio: text('bio'),
+  profilePictureUrl: text('profile_picture_url'),
+  preferences: json('preferences'),
+  tags: json('tags').$type<string[]>(),
+  metadata: json('metadata'),
+}, (table) => ({
+  // 複合インデックス
+  fullNameIdx: index('users_full_name_idx').on(table.firstName, table.lastName),
+  // 部分インデックス（MySQLでは通常のインデックスとして実装）
+  activeUsersEmailIdx: index('users_active_email_idx').on(table.email),
+  // JSONフィールドのインデックス（MySQLでは仮想列経由が推奨）
+  tagsIdx: index('users_tags_idx').on(table.tags),
+  // ユニークインデックス
+  verifiedEmailIdx: uniqueIndex('users_verified_email_unique_idx').on(table.email),
+  // CHECK制約
+  ageCheck: check('users_age_check', sql`age >= 0 AND age <= 150`),
+  usernameCheck: check('users_username_check', sql`CHAR_LENGTH(username) >= 3`),
+}))
+
+export const categories = mysqlTable('categories', {
+  id: serial('id').primaryKey(),
+  name: varchar('name', { length: 100 }).notNull().unique(),
+  slug: varchar('slug', { length: 100 }).notNull().unique(),
+  description: text('description'),
+  parentId: int('parent_id'),
+  isActive: boolean('is_active').default(true).notNull(),
+  sortOrder: int('sort_order').default(0).notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull().onUpdateNow(),
+}, (table) => ({
+  // Index for hierarchical queries
+  parentIdIdx: index('categories_parent_id_idx').on(table.parentId),
+  // Composite unique constraint
+  parentSlugUnique: unique('categories_parent_slug_unique').on(table.parentId, table.slug),
+  // Index for active categories
+  activeCategoriesIdx: index('categories_active_idx').on(table.name, table.isActive),
+  // CHECK constraint
+  sortOrderCheck: check('categories_sort_order_check', sql`sort_order >= 0`),
+}))
+
+export const products = mysqlTable('products', {
+  id: serial('id').primaryKey(),
+  sku: varchar('sku', { length: 50 }).notNull().unique(),
+  name: varchar('name', { length: 255 }).notNull(),
+  description: text('description'),
+  shortDescription: varchar('short_description', { length: 500 }),
+  price: decimal('price', { precision: 10, scale: 2 }).notNull(),
+  compareAtPrice: decimal('compare_at_price', { precision: 10, scale: 2 }),
+  costPrice: decimal('cost_price', { precision: 10, scale: 2 }),
+  weight: decimal('weight', { precision: 8, scale: 3 }),
+  dimensions: json('dimensions'),
+  categoryId: int('category_id').notNull().references(() => categories.id, {
+    onDelete: 'restrict',
+    onUpdate: 'cascade'
+  }),
+  brandId: int('brand_id').references(() => brands.id, {
+    onDelete: 'set null',
+    onUpdate: 'cascade'
+  }),
+  isActive: boolean('is_active').default(true).notNull(),
+  isFeatured: boolean('is_featured').default(false).notNull(),
+  stockQuantity: int('stock_quantity').default(0).notNull(),
+  lowStockThreshold: int('low_stock_threshold').default(10).notNull(),
+  tags: json('tags').$type<string[]>(),
+  seoTitle: varchar('seo_title', { length: 255 }),
+  seoDescription: text('seo_description'),
+  publishedAt: timestamp('published_at'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull().onUpdateNow(),
+}, (table) => ({
+  // Composite index for category and active status
+  categoryActiveIdx: index('products_category_active_idx')
+    .on(table.categoryId, table.isActive),
+  // Featured products index
+  featuredIdx: index('products_featured_idx')
+    .on(table.isFeatured, table.isActive),
+  // Price range index
+  priceIdx: index('products_price_idx').on(table.price),
+  // Low stock index
+  lowStockIdx: index('products_low_stock_idx')
+    .on(table.stockQuantity),
+  // Brand index
+  brandIdx: index('products_brand_idx').on(table.brandId),
+  // Unique SKU per brand
+  brandSkuUnique: unique('products_brand_sku_unique').on(table.brandId, table.sku),
+  // CHECK constraints
+  pricePositiveCheck: check('products_price_positive', sql`price > 0`),
+  stockNonNegativeCheck: check('products_stock_non_negative', sql`stock_quantity >= 0`),
+  thresholdPositiveCheck: check('products_threshold_positive', sql`low_stock_threshold > 0`),
+  compareAtPriceCheck: check('products_compare_at_price_check', 
+    sql`compare_at_price IS NULL OR compare_at_price >= price`),
+}))
+
+export const brands = mysqlTable('brands', {
+  id: serial('id').primaryKey(),
+  name: varchar('name', { length: 100 }).notNull().unique(),
+  slug: varchar('slug', { length: 100 }).notNull().unique(),
+  description: text('description'),
+  logoUrl: text('logo_url'),
+  websiteUrl: text('website_url'),
+  isActive: boolean('is_active').default(true).notNull(),
+  foundedYear: int('founded_year'),
+  countryCode: varchar('country_code', { length: 2 }),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull().onUpdateNow(),
+}, (table) => ({
+  // Active brands index
+  activeIdx: index('brands_active_idx')
+    .on(table.name, table.isActive),
+  // Country index
+  countryIdx: index('brands_country_idx').on(table.countryCode),
+  // CHECK constraints
+  foundedYearCheck: check('brands_founded_year_check', 
+    sql`founded_year >= 1800 AND founded_year <= YEAR(NOW())`),
+  countryCodeCheck: check('brands_country_code_check', 
+    sql`country_code REGEXP '^[A-Z]{2}$'`),
+}))
+
+export const orders = mysqlTable('orders', {
+  id: serial('id').primaryKey(),
+  orderNumber: varchar('order_number', { length: 50 }).notNull().unique(),
+  userId: int('user_id').notNull().references(() => users.id, {
+    onDelete: 'restrict',
+    onUpdate: 'cascade'
+  }),
+  status: orderStatusEnum('status').default('pending').notNull(),
+  subtotal: decimal('subtotal', { precision: 10, scale: 2 }).notNull(),
+  taxAmount: decimal('tax_amount', { precision: 10, scale: 2 }).default('0').notNull(),
+  shippingAmount: decimal('shipping_amount', { precision: 10, scale: 2 }).default('0').notNull(),
+  discountAmount: decimal('discount_amount', { precision: 10, scale: 2 }).default('0').notNull(),
+  totalAmount: decimal('total_amount', { precision: 10, scale: 2 }).notNull(),
+  currency: varchar('currency', { length: 3 }).default('USD').notNull(),
+  paymentMethod: paymentMethodEnum('payment_method'),
+  paymentStatus: varchar('payment_status', { length: 20 }).default('pending').notNull(),
+  shippingAddress: json('shipping_address'),
+  billingAddress: json('billing_address'),
+  notes: text('notes'),
+  shippedAt: timestamp('shipped_at'),
+  deliveredAt: timestamp('delivered_at'),
+  cancelledAt: timestamp('cancelled_at'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull().onUpdateNow(),
+}, (table) => ({
+  // User orders index
+  userIdIdx: index('orders_user_id_idx').on(table.userId),
+  // Status index
+  statusIdx: index('orders_status_idx').on(table.status),
+  // Date range queries
+  createdAtIdx: index('orders_created_at_idx').on(table.createdAt),
+  // Payment status index
+  paymentStatusIdx: index('orders_payment_status_idx').on(table.paymentStatus),
+  // Composite index for user and status
+  userStatusIdx: index('orders_user_status_idx').on(table.userId, table.status),
+  // Active orders
+  activeOrdersIdx: index('orders_active_idx')
+    .on(table.status, table.createdAt),
+  // CHECK constraints
+  subtotalPositiveCheck: check('orders_subtotal_positive', sql`subtotal >= 0`),
+  totalPositiveCheck: check('orders_total_positive', sql`total_amount >= 0`),
+  taxNonNegativeCheck: check('orders_tax_non_negative', sql`tax_amount >= 0`),
+  shippingNonNegativeCheck: check('orders_shipping_non_negative', sql`shipping_amount >= 0`),
+  discountNonNegativeCheck: check('orders_discount_non_negative', sql`discount_amount >= 0`),
+  currencyFormatCheck: check('orders_currency_format', sql`currency REGEXP '^[A-Z]{3}$'`),
+  statusDateCheck: check('orders_status_date_check', 
+    sql`(shipped_at IS NULL OR shipped_at >= created_at) AND 
+        (delivered_at IS NULL OR delivered_at >= COALESCE(shipped_at, created_at)) AND
+        (cancelled_at IS NULL OR cancelled_at >= created_at)`),
+}))
+
+export const orderItems = mysqlTable('order_items', {
+  id: serial('id').primaryKey(),
+  orderId: int('order_id').notNull().references(() => orders.id, {
+    onDelete: 'cascade',
+    onUpdate: 'cascade'
+  }),
+  productId: int('product_id').notNull().references(() => products.id, {
+    onDelete: 'restrict',
+    onUpdate: 'cascade'
+  }),
+  quantity: int('quantity').notNull(),
+  unitPrice: decimal('unit_price', { precision: 10, scale: 2 }).notNull(),
+  totalPrice: decimal('total_price', { precision: 10, scale: 2 }).notNull(),
+  productSnapshot: json('product_snapshot'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => ({
+  // Order items lookup
+  orderIdIdx: index('order_items_order_id_idx').on(table.orderId),
+  // Product sales analysis
+  productIdIdx: index('order_items_product_id_idx').on(table.productId),
+  // Composite unique constraint - prevent duplicate products in same order
+  orderProductUnique: unique('order_items_order_product_unique').on(table.orderId, table.productId),
+  // CHECK constraints
+  quantityPositiveCheck: check('order_items_quantity_positive', sql`quantity > 0`),
+  unitPricePositiveCheck: check('order_items_unit_price_positive', sql`unit_price > 0`),
+  totalPriceCheck: check('order_items_total_price_check', 
+    sql`total_price = unit_price * quantity`),
+}))
+
+export const reviews = mysqlTable('reviews', {
+  id: serial('id').primaryKey(),
+  productId: int('product_id').notNull().references(() => products.id, {
+    onDelete: 'cascade',
+    onUpdate: 'cascade'
+  }),
+  userId: int('user_id').notNull().references(() => users.id, {
+    onDelete: 'cascade',
+    onUpdate: 'cascade'
+  }),
+  orderId: int('order_id').references(() => orders.id, {
+    onDelete: 'set null',
+    onUpdate: 'cascade'
+  }),
+  rating: int('rating').notNull(),
+  title: varchar('title', { length: 255 }),
+  content: text('content'),
+  isVerifiedPurchase: boolean('is_verified_purchase').default(false).notNull(),
+  isApproved: boolean('is_approved').default(true).notNull(),
+  helpfulVotes: int('helpful_votes').default(0).notNull(),
+  totalVotes: int('total_votes').default(0).notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull().onUpdateNow(),
+}, (table) => ({
+  // Product reviews lookup
+  productIdIdx: index('reviews_product_id_idx').on(table.productId),
+  // User reviews lookup
+  userIdIdx: index('reviews_user_id_idx').on(table.userId),
+  // Rating analysis
+  ratingIdx: index('reviews_rating_idx').on(table.rating),
+  // Approved reviews
+  approvedIdx: index('reviews_approved_idx')
+    .on(table.productId, table.rating, table.isApproved),
+  // Verified purchase reviews
+  verifiedIdx: index('reviews_verified_idx')
+    .on(table.productId, table.isVerifiedPurchase),
+  // One review per user per product
+  userProductUnique: unique('reviews_user_product_unique').on(table.userId, table.productId),
+  // CHECK constraints
+  ratingRangeCheck: check('reviews_rating_range', sql`rating >= 1 AND rating <= 5`),
+  votesCheck: check('reviews_votes_check', 
+    sql`helpful_votes >= 0 AND total_votes >= helpful_votes`),
+}))
+
+// ========================================
+// Many-to-Many Junction Tables
+// ========================================
+
+export const productTags = mysqlTable('product_tags', {
+  productId: int('product_id').notNull().references(() => products.id, {
+    onDelete: 'cascade',
+    onUpdate: 'cascade'
+  }),
+  tagId: int('tag_id').notNull().references(() => tags.id, {
+    onDelete: 'cascade',
+    onUpdate: 'cascade'
+  }),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => ({
+  // Composite primary key
+  pk: primaryKey({ columns: [table.productId, table.tagId] }),
+  // Index for tag-based queries
+  tagIdIdx: index('product_tags_tag_id_idx').on(table.tagId),
+}))
+
+export const tags = mysqlTable('tags', {
+  id: serial('id').primaryKey(),
+  name: varchar('name', { length: 50 }).notNull().unique(),
+  slug: varchar('slug', { length: 50 }).notNull().unique(),
+  description: text('description'),
+  color: varchar('color', { length: 7 }),
+  isActive: boolean('is_active').default(true).notNull(),
+  usageCount: int('usage_count').default(0).notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => ({
+  // Active tags index
+  activeIdx: index('tags_active_idx')
+    .on(table.name, table.isActive),
+  // Usage count for popular tags
+  usageCountIdx: index('tags_usage_count_idx').on(table.usageCount),
+  // CHECK constraints
+  colorFormatCheck: check('tags_color_format', sql`color REGEXP '^#[0-9A-Fa-f]{6}$'`),
+  usageCountNonNegativeCheck: check('tags_usage_count_non_negative', sql`usage_count >= 0`),
+}))
+
+// ========================================
+// Relations
+// ========================================
+
+export const usersRelations = relations(users, ({ many }) => ({
+  orders: many(orders),
+  reviews: many(reviews),
+}))
+
+export const categoriesRelations = relations(categories, ({ one, many }) => ({
+  parent: one(categories, {
+    fields: [categories.parentId],
+    references: [categories.id],
+    relationName: 'CategoryHierarchy',
+  }),
+  children: many(categories, {
+    relationName: 'CategoryHierarchy',
+  }),
+  products: many(products),
+}))
+
+export const brandsRelations = relations(brands, ({ many }) => ({
+  products: many(products),
+}))
+
+export const productsRelations = relations(products, ({ one, many }) => ({
+  category: one(categories, {
+    fields: [products.categoryId],
+    references: [categories.id],
+  }),
+  brand: one(brands, {
+    fields: [products.brandId],
+    references: [brands.id],
+  }),
+  orderItems: many(orderItems),
+  reviews: many(reviews),
+  productTags: many(productTags),
+}))
+
+export const ordersRelations = relations(orders, ({ one, many }) => ({
+  user: one(users, {
+    fields: [orders.userId],
+    references: [users.id],
+  }),
+  orderItems: many(orderItems),
+  reviews: many(reviews),
+}))
+
+export const orderItemsRelations = relations(orderItems, ({ one }) => ({
+  order: one(orders, {
+    fields: [orderItems.orderId],
+    references: [orders.id],
+  }),
+  product: one(products, {
+    fields: [orderItems.productId],
+    references: [products.id],
+  }),
+}))
+
+export const reviewsRelations = relations(reviews, ({ one }) => ({
+  product: one(products, {
+    fields: [reviews.productId],
+    references: [products.id],
+  }),
+  user: one(users, {
+    fields: [reviews.userId],
+    references: [users.id],
+  }),
+  order: one(orders, {
+    fields: [reviews.orderId],
+    references: [orders.id],
+  }),
+}))
+
+export const tagsRelations = relations(tags, ({ many }) => ({
+  productTags: many(productTags),
+}))
+
+export const productTagsRelations = relations(productTags, ({ one }) => ({
+  product: one(products, {
+    fields: [productTags.productId],
+    references: [products.id],
+  }),
+  tag: one(tags, {
+    fields: [productTags.tagId],
+    references: [tags.id],
+  }),
+}))

--- a/drizzle/mysql/composite-foreign-keys/schema.ts
+++ b/drizzle/mysql/composite-foreign-keys/schema.ts
@@ -1,0 +1,27 @@
+import { mysqlTable, int, primaryKey } from 'drizzle-orm/mysql-core';
+
+export const projectUsers = mysqlTable(
+  'project_users',
+  {
+    projectId: int('project_id').notNull(),
+    userId: int('user_id').notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.projectId, table.userId] }),
+  })
+);
+
+export const projectTasks = mysqlTable(
+  'project_tasks',
+  {
+    projectId: int('project_id').notNull(),
+    userId: int('user_id').notNull(),
+    taskId: int('task_id').notNull(),
+  },
+  (table) => ({
+    fk: {
+      columns: [table.projectId, table.userId],
+      foreignColumns: [projectUsers.projectId, projectUsers.userId],
+    },
+  })
+);

--- a/drizzle/mysql/composite-keys/schema.ts
+++ b/drizzle/mysql/composite-keys/schema.ts
@@ -1,0 +1,201 @@
+import { mysqlTable, text, int, timestamp, primaryKey } from 'drizzle-orm/mysql-core';
+import { relations } from 'drizzle-orm';
+
+// Example 1: User and role relationship table (user_id + role_id)
+export const userRoles = mysqlTable('user_roles', {
+  userId: int('user_id').notNull().references(() => users.id, {
+    onDelete: 'cascade'
+  }),
+  roleId: int('role_id').notNull().references(() => roles.id, {
+    onDelete: 'cascade'
+  }),
+  assignedAt: timestamp('assigned_at').defaultNow(),
+  assignedBy: int('assigned_by').references(() => users.id, {
+    onDelete: 'set null'
+  }),
+}, (table) => {
+  return {
+    pk: primaryKey({ columns: [table.userId, table.roleId] }),
+  };
+});
+
+// Example 2: Order details table (order_id + product_id)
+export const orderItems = mysqlTable('order_items', {
+  orderId: int('order_id').notNull().references(() => orders.id, {
+    onDelete: 'cascade'
+  }),
+  productId: int('product_id').notNull().references(() => products.id, {
+    onDelete: 'cascade'
+  }),
+  quantity: int('quantity').notNull(),
+  unitPrice: int('unit_price').notNull(),
+  createdAt: timestamp('created_at').defaultNow(),
+}, (table) => {
+  return {
+    pk: primaryKey({ columns: [table.orderId, table.productId] }),
+  };
+});
+
+// Example 3: Multilingual support table (entity_id + language_code)
+export const translations = mysqlTable('translations', {
+  entityId: int('entity_id').notNull().references(() => entities.id, {
+    onDelete: 'cascade'
+  }),
+  languageCode: text('language_code').notNull(),
+  title: text('title').notNull(),
+  description: text('description'),
+  updatedAt: timestamp('updated_at').defaultNow().onUpdateNow(),
+}, (table) => {
+  return {
+    pk: primaryKey({ columns: [table.entityId, table.languageCode] }),
+  };
+});
+
+// Example 4: Time series data table (device_id + timestamp)
+export const sensorData = mysqlTable('sensor_data', {
+  deviceId: text('device_id').notNull().references(() => devices.id, {
+    onDelete: 'cascade'
+  }),
+  timestamp: timestamp('timestamp').notNull(),
+  temperature: int('temperature'),
+  humidity: int('humidity'),
+  batteryLevel: int('battery_level'),
+}, (table) => {
+  return {
+    pk: primaryKey({ columns: [table.deviceId, table.timestamp] }),
+  };
+});
+
+// Example 5: Three-column composite primary key
+export const userProjectPermissions = mysqlTable('user_project_permissions', {
+  userId: int('user_id').notNull().references(() => users.id, {
+    onDelete: 'cascade'
+  }),
+  projectId: int('project_id').notNull().references(() => projects.id, {
+    onDelete: 'cascade'
+  }),
+  permission: text('permission').notNull(), // 'read', 'write', 'admin'
+  grantedAt: timestamp('granted_at').defaultNow(),
+  grantedBy: int('granted_by').references(() => users.id, {
+    onDelete: 'set null'
+  }),
+}, (table) => {
+  return {
+    pk: primaryKey({ columns: [table.userId, table.projectId, table.permission] }),
+  };
+});
+
+// Reference: Single primary key table (for comparison)
+export const users = mysqlTable('users', {
+  id: int('id').primaryKey().autoincrement(),
+  name: text('name').notNull(),
+  email: text('email').notNull(),
+  createdAt: timestamp('created_at').defaultNow(),
+});
+
+export const roles = mysqlTable('roles', {
+  id: int('id').primaryKey().autoincrement(),
+  name: text('name').notNull(),
+  description: text('description'),
+});
+
+// Relations definitions
+export const usersRelations = relations(users, ({ many }) => ({
+  userRoles: many(userRoles),
+  userProjectPermissions: many(userProjectPermissions),
+}));
+
+export const rolesRelations = relations(roles, ({ many }) => ({
+  userRoles: many(userRoles),
+}));
+
+export const userRolesRelations = relations(userRoles, ({ one }) => ({
+  user: one(users, {
+    fields: [userRoles.userId],
+    references: [users.id],
+  }),
+  role: one(roles, {
+    fields: [userRoles.roleId],
+    references: [roles.id],
+  }),
+  assignedByUser: one(users, {
+    fields: [userRoles.assignedBy],
+    references: [users.id],
+  }),
+}));
+
+export const orderItemsRelations = relations(orderItems, ({ one }) => ({
+  order: one(orders, {
+    fields: [orderItems.orderId],
+    references: [orders.id],
+  }),
+  product: one(products, {
+    fields: [orderItems.productId],
+    references: [products.id],
+  }),
+}));
+
+export const translationsRelations = relations(translations, ({ one }) => ({
+  entity: one(entities, {
+    fields: [translations.entityId],
+    references: [entities.id],
+  }),
+}));
+
+export const sensorDataRelations = relations(sensorData, ({ one }) => ({
+  device: one(devices, {
+    fields: [sensorData.deviceId],
+    references: [devices.id],
+  }),
+}));
+
+export const userProjectPermissionsRelations = relations(userProjectPermissions, ({ one }) => ({
+  user: one(users, {
+    fields: [userProjectPermissions.userId],
+    references: [users.id],
+  }),
+  project: one(projects, {
+    fields: [userProjectPermissions.projectId],
+    references: [projects.id],
+  }),
+  grantedByUser: one(users, {
+    fields: [userProjectPermissions.grantedBy],
+    references: [users.id],
+  }),
+}));
+
+// Additional related tables (for demonstration)
+export const orders = mysqlTable('orders', {
+  id: int('id').primaryKey().autoincrement(),
+  userId: int('user_id').notNull().references(() => users.id, {
+    onDelete: 'cascade'
+  }),
+  total: int('total').notNull(),
+  createdAt: timestamp('created_at').defaultNow(),
+});
+
+export const products = mysqlTable('products', {
+  id: int('id').primaryKey().autoincrement(),
+  name: text('name').notNull(),
+  price: int('price').notNull(),
+});
+
+export const entities = mysqlTable('entities', {
+  id: int('id').primaryKey().autoincrement(),
+  type: text('type').notNull(), // 'article', 'product', etc.
+  createdAt: timestamp('created_at').defaultNow(),
+});
+
+export const devices = mysqlTable('devices', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  location: text('location'),
+  installedAt: timestamp('installed_at').defaultNow(),
+});
+
+export const projects = mysqlTable('projects', {
+  id: int('id').primaryKey().autoincrement(),
+  name: text('name').notNull(),
+  description: text('description'),
+  createdAt: timestamp('created_at').defaultNow(),
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "declaration": true,
-    "declarationMap": true,
+     "declarationMap": true,
     "outDir": "./dist",
     "rootDir": "./",
     "types": ["node"]


### PR DESCRIPTION
- Introduced `schema.ts` files for basic and advanced MySQL schemas, defining various tables and relationships.
- Created `composite-foreign-keys/schema.ts` to demonstrate composite foreign key usage.
- Added `composite-keys/schema.ts` to illustrate multiple examples of composite keys and their relationships.